### PR TITLE
Save calculated correlations in JSON column on tournament

### DIFF
--- a/app/controllers/tournaments_controller.rb
+++ b/app/controllers/tournaments_controller.rb
@@ -10,7 +10,7 @@ class TournamentsController < ApplicationController
     @data_sources = @tournament.data_sources.uniq
     @data_points = @tournament.data_points
     @golfers = @tournament.golfers.uniq
-    @correlations = CorrelationCalculator.calculate(@tournament)
+    @correlations = JSON.parse(@tournament.correlations)
   end
 
   private

--- a/app/services/correlation_calculator.rb
+++ b/app/services/correlation_calculator.rb
@@ -8,14 +8,18 @@ class CorrelationCalculator
   end
 
   def calculate
-    data_sources.each_with_object({}) do |source, hash|
-      hash[source.stat] = correlation(source.stat)
-    end.sort_by { |_, correlations| -correlations }.to_h
+    tournament.update(correlations: correlations.to_json)
   end
 
   private
 
   attr_reader :tournament
+
+  def correlations
+    data_sources.each_with_object({}) do |source, hash|
+      hash[source.stat] = correlation(source.stat)
+    end.sort_by { |_, correlations| -correlations }.to_h
+  end
 
   def correlation(stat)
     Pearson.coefficient(scores, DataSource::RESULTS, stat).truncate(5)

--- a/db/migrate/20200816004358_add_correlation_to_tournaments.rb
+++ b/db/migrate/20200816004358_add_correlation_to_tournaments.rb
@@ -1,0 +1,5 @@
+class AddCorrelationToTournaments < ActiveRecord::Migration[6.0]
+  def change
+    add_column :tournaments, :correlations, :json
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_11_105131) do
+ActiveRecord::Schema.define(version: 2020_08_16_004358) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -55,6 +55,7 @@ ActiveRecord::Schema.define(version: 2020_08_11_105131) do
     t.integer "year"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.json "correlations"
   end
 
   add_foreign_key "data_points", "data_sources"


### PR DESCRIPTION
Rather than recalculating the correlations every time a user loads the tournament show page, this updates the service to calculate them and save them on the tournament record, which the show page will access.

This means that we'll now need to calculate correlations for all tournaments at some point, as that data will not be available until we explicitly do so.