### PR TITLE
Data source

### DIFF
--- a/app/models/data_source.rb
+++ b/app/models/data_source.rb
@@ -10,7 +10,7 @@ class DataSource < ApplicationRecord
   validates :stat, uniqueness: true
 
   def self.not_yet_pulled_for(tournament)
-    DataSource.all - tournament.data_sources.uniq
+    DataSource.where.not(id: tournament.data_sources)
   end
 
   def results_stat?

--- a/db/migrate/20200816012229_add_default_to_correlations.rb
+++ b/db/migrate/20200816012229_add_default_to_correlations.rb
@@ -1,0 +1,5 @@
+class AddDefaultToCorrelations < ActiveRecord::Migration[6.0]
+  def change
+    change_column_default :tournaments, :correlations, '{}'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_16_004358) do
+ActiveRecord::Schema.define(version: 2020_08_16_012229) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -55,7 +55,7 @@ ActiveRecord::Schema.define(version: 2020_08_16_004358) do
     t.integer "year"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.json "correlations"
+    t.json "correlations", default: "{}"
   end
 
   add_foreign_key "data_points", "data_sources"


### PR DESCRIPTION
Fixes issue where tournament show pages crash without correlations
Improves `not_yet_pulled_for` scope on `DataSource` - closes #16