### PR TITLE
Scrape tournaments

### DIFF
--- a/app/services/correlation_calculator.rb
+++ b/app/services/correlation_calculator.rb
@@ -3,6 +3,12 @@ class CorrelationCalculator
     new(tournament).calculate
   end
 
+  def self.calculate_for_series(pga_id)
+    Tournament.where(pga_id: pga_id).each do |tournament|
+      new(tournament).calculate
+    end
+  end
+
   def initialize(tournament)
     @tournament = tournament
   end

--- a/app/services/scraper.rb
+++ b/app/services/scraper.rb
@@ -122,7 +122,7 @@ class Scraper
 
       "https://www.pgatour.com/tournaments/#{name}/past-results/jcr:content/mainParsys/pastresults.selectedYear.#{tournament.year}.html"
     else
-      "https://www.pgatour.com/content/pgatour/stats/stat.#{source.pga_id}.y#{tournament.year}.eon.#{tournament.pga_id}.html"
+      "https://www.pgatour.com/stats/stat.#{source.pga_id}.y#{tournament.year}.eon.#{tournament.pga_id}.html"
     end
   end
 end

--- a/app/workers/data_scraper_worker.rb
+++ b/app/workers/data_scraper_worker.rb
@@ -2,6 +2,6 @@ class DataScraperWorker < ApplicationWorker
   sidekiq_options retry: false
 
   def perform
-    Scraper.scrape_data
+    Scraper.scrape_data_from_all_tournaments
   end
 end

--- a/app/workers/tournament_scraper_worker.rb
+++ b/app/workers/tournament_scraper_worker.rb
@@ -2,6 +2,6 @@ class TournamentScraperWorker < ApplicationWorker
   sidekiq_options retry: false
 
   def perform
-    Scraper.scrape_new_tournaments
+    Scraper.scrape_for_new_tournaments
   end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -76,6 +76,9 @@ data_sources = [
     stat_column_name: 'average',
     pga_id: '02564',
   },
+  {
+    stat: DataSource::RESULTS,
+  },
 ]
 
 data_sources.each do |source|

--- a/spec/services/scraper_spec.rb
+++ b/spec/services/scraper_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Scraper, type: :service do
     allow_any_instance_of(Scraper).to receive(:sleep)
   end
 
-  describe '#scrape_all_tournaments' do
+  describe '#scrape_for_all_tournaments' do
     context 'when tournaments were scraped recently' do
       before do
         create(
@@ -20,38 +20,38 @@ RSpec.describe Scraper, type: :service do
       end
 
       it 'does not make any requests' do
-        service.scrape_all_tournaments
+        service.scrape_for_all_tournaments
 
         expect(HTTParty).not_to have_received(:get)
       end
 
       it 'does not log a scrape' do
-        expect { service.scrape_all_tournaments }.not_to change { ScrapeLogger.tournament.count }
+        expect { service.scrape_for_all_tournaments }.not_to change { ScrapeLogger.tournament.count }
       end
     end
 
     context 'when tournaments were not scraped recently' do
       it 'makes 1 request to the PGA site per year' do
-        service.scrape_all_tournaments
+        service.scrape_for_all_tournaments
 
         expect(HTTParty).to have_received(:get).exactly(Scraper::YEARS.length).times
       end
 
       it 'creates a Tournament for each tournament found' do
-        expect { service.scrape_all_tournaments }
+        expect { service.scrape_for_all_tournaments }
           .to change { Tournament.count }
           .from(0).to(26 * Scraper::YEARS.length)
       end
 
       it 'logs a scrape' do
-        expect { service.scrape_new_tournaments }
+        expect { service.scrape_for_new_tournaments }
           .to change { ScrapeLogger.tournament.count }
           .from(0).to(1)
       end
     end
   end
 
-  describe '#scrape_new_tournaments' do
+  describe '#scrape_for_new_tournaments' do
     context 'when tournaments were scraped recently' do
       before do
         create(
@@ -62,39 +62,39 @@ RSpec.describe Scraper, type: :service do
       end
 
       it 'does not make any requests' do
-        service.scrape_new_tournaments
+        service.scrape_for_new_tournaments
 
         expect(HTTParty).not_to have_received(:get)
       end
 
       it 'does not log a scrape' do
-        expect { service.scrape_new_tournaments }.not_to change { ScrapeLogger.tournament.count }
+        expect { service.scrape_for_new_tournaments }.not_to change { ScrapeLogger.tournament.count }
       end
     end
 
     context 'when tournaments were not scraped recently' do
       it 'makes 1 request to the 2020 PGA site' do
-        service.scrape_new_tournaments
+        service.scrape_for_new_tournaments
 
         expect(HTTParty).to have_received(:get).exactly(1).times
         expect(HTTParty).to have_received(:get).with("https://www.pgatour.com/stats/stat.02674.y2020.eon.t033.html")
       end
 
       it 'creates a Tournament for each tournament found' do
-        expect { service.scrape_new_tournaments }
+        expect { service.scrape_for_new_tournaments }
           .to change { Tournament.count }
           .from(0).to(26)
       end
 
       it 'logs a scrape' do
-        expect { service.scrape_new_tournaments }
+        expect { service.scrape_for_new_tournaments }
           .to change { ScrapeLogger.tournament.count }
           .from(0).to(1)
       end
     end
   end
 
-  describe '#scrape_data' do
+  describe '#scrape_data_from_all_tournaments' do
     context 'when data was scraped recently' do
       before do
         create(
@@ -105,13 +105,13 @@ RSpec.describe Scraper, type: :service do
       end
 
       it 'does not make any requests' do
-        service.scrape_data
+        service.scrape_data_from_all_tournaments
 
         expect(HTTParty).not_to have_received(:get)
       end
 
       it 'does not log a scrape' do
-        expect { service.scrape_data }.not_to change { ScrapeLogger.data.count }
+        expect { service.scrape_data_from_all_tournaments }.not_to change { ScrapeLogger.data.count }
       end
     end
 
@@ -127,13 +127,13 @@ RSpec.describe Scraper, type: :service do
         end
 
         it 'does not make any requests' do
-          service.scrape_data
+          service.scrape_data_from_all_tournaments
 
           expect(HTTParty).not_to have_received(:get)
         end
 
         it 'logs a scrape' do
-          expect { service.scrape_data }
+          expect { service.scrape_data_from_all_tournaments }
             .to change { ScrapeLogger.data.count }
             .from(0).to(1)
         end
@@ -152,12 +152,12 @@ RSpec.describe Scraper, type: :service do
         end
 
         it 'makes 1 request to the PGA site for each tournament, for the one unaccounted-for data source' do
-          service.scrape_data
+          service.scrape_data_from_all_tournaments
 
           expect(HTTParty).to have_received(:get)
-          .with("https://www.pgatour.com/content/pgatour/stats/stat.#{data_source_2.pga_id}.y#{tournament_1.year}.eon.#{tournament_1.pga_id}.html")
+            .with("https://www.pgatour.com/content/pgatour/stats/stat.#{data_source_2.pga_id}.y#{tournament_1.year}.eon.#{tournament_1.pga_id}.html")
           expect(HTTParty).to have_received(:get)
-          .with("https://www.pgatour.com/content/pgatour/stats/stat.#{data_source_2.pga_id}.y#{tournament_2.year}.eon.#{tournament_2.pga_id}.html")
+            .with("https://www.pgatour.com/content/pgatour/stats/stat.#{data_source_2.pga_id}.y#{tournament_2.year}.eon.#{tournament_2.pga_id}.html")
           expect(HTTParty).to have_received(:get).exactly(2).times
         end
 
@@ -165,7 +165,7 @@ RSpec.describe Scraper, type: :service do
 
           expect(DataPoint.count).to eq(2)
 
-          service.scrape_data
+          service.scrape_data_from_all_tournaments
 
           number_of_golfers_in_fixture = 5
           tournaments = Tournament.count
@@ -183,7 +183,7 @@ RSpec.describe Scraper, type: :service do
         end
 
         it 'logs a scrape' do
-          expect { service.scrape_data }
+          expect { service.scrape_data_from_all_tournaments }
             .to change { ScrapeLogger.data.count }
             .from(0).to(1)
         end

--- a/spec/workers/data_scraper_worker_spec.rb
+++ b/spec/workers/data_scraper_worker_spec.rb
@@ -5,12 +5,12 @@ RSpec.describe DataScraperWorker, type: :worker do
 
     subject(:worker) { DataScraperWorker.new }
 
-    it 'calls #scrape_data on DataScraper' do
-      allow(Scraper).to receive(:scrape_data)
+    it 'calls #scrape_data_from_all_tournaments on DataScraper' do
+      allow(Scraper).to receive(:scrape_data_from_all_tournaments)
 
       worker.perform
 
-      expect(Scraper).to have_received(:scrape_data)
+      expect(Scraper).to have_received(:scrape_data_from_all_tournaments)
     end
   end
 end

--- a/spec/workers/tournament_scraper_worker_spec.rb
+++ b/spec/workers/tournament_scraper_worker_spec.rb
@@ -5,12 +5,12 @@ RSpec.describe TournamentScraperWorker, type: :worker do
 
     subject(:worker) { TournamentScraperWorker.new }
 
-    it 'calls #scrape_new_tournaments on TournamentScraper' do
-      allow(Scraper).to receive(:scrape_new_tournaments)
+    it 'calls #scrape_for_new_tournaments on TournamentScraper' do
+      allow(Scraper).to receive(:scrape_for_new_tournaments)
 
       worker.perform
 
-      expect(Scraper).to have_received(:scrape_new_tournaments)
+      expect(Scraper).to have_received(:scrape_for_new_tournaments)
     end
   end
 end


### PR DESCRIPTION
- Adds ability to scrape data from individual tournament series (closes #18 )
- Adds ability to correlate correlations for an entire tournament series (closes #19 )
- Updates the URL for stat-related data sources - some of the pages are currently being redirected to the url in this PR, which HTTParty can't follow.