### PR TITLE
Update sidekiq scheduler initializer to never run

### DIFF
--- a/config/initializers/scheduler.rb
+++ b/config/initializers/scheduler.rb
@@ -1,6 +1,8 @@
-Sidekiq.configure_server do |config|
-  config.on(:startup) do
-    Sidekiq.schedule = YAML.load_file(File.expand_path('../../sidekiq_scheduler.yml', __FILE__))
-    Sidekiq::Scheduler.reload_schedule!
+if false
+  Sidekiq.configure_server do |config|
+    config.on(:startup) do
+      Sidekiq.schedule = YAML.load_file(File.expand_path('../../sidekiq_scheduler.yml', __FILE__))
+      Sidekiq::Scheduler.reload_schedule!
+    end
   end
 end


### PR DESCRIPTION
This is a temporary fix (obviously) until I figure out how to control whether the scheduler is turned on using environment variables