### PR TITLE
Create UrlBuilder to update & encapsulate url logic

### DIFF
--- a/app/services/scraper.rb
+++ b/app/services/scraper.rb
@@ -62,8 +62,7 @@ class Scraper
   end
 
   def scrape_data_source(source, tournament)
-    url = url_builder(source, tournament)
-
+    url = UrlBuilder.build(source, tournament)
     unparsed_page = HTTParty.get(url)
     results = Parser.parse_table(unparsed_page, source)
 
@@ -115,16 +114,6 @@ class Scraper
       }
 
       Tournament.find_or_create_by(data)
-    end
-  end
-
-  def url_builder(source, tournament)
-    if source.results_stat?
-      name = tournament.name.gsub(" ", "-").downcase
-
-      "https://www.pgatour.com/tournaments/#{name}/past-results/jcr:content/mainParsys/pastresults.selectedYear.#{tournament.year}.html"
-    else
-      "https://www.pgatour.com/stats/stat.#{source.pga_id}.y#{tournament.year}.eon.#{tournament.pga_id}.html"
     end
   end
 end

--- a/app/services/url_builder.rb
+++ b/app/services/url_builder.rb
@@ -1,0 +1,38 @@
+class UrlBuilder
+  def self.build(source, tournament)
+    new(source, tournament).build
+  end
+
+  def initialize(source, tournament)
+    @source = source
+    @tournament = tournament
+  end
+
+  def build
+    if source.results_stat?
+      results_url
+    else
+      stats_url
+    end
+  end
+
+  private
+
+  attr_reader :source, :tournament
+
+  def tournament_name
+    most_recent_matching_tournament.name.gsub(" ", "-").downcase
+  end
+
+  def most_recent_matching_tournament
+    Tournament.where(pga_id: tournament.pga_id).order(year: :desc).first
+  end
+
+  def results_url
+    "https://www.pgatour.com/tournaments/#{tournament_name}/past-results/jcr:content/mainParsys/pastresults.selectedYear.#{tournament.year}.html"
+  end
+
+  def stats_url
+    "https://www.pgatour.com/stats/stat.#{source.pga_id}.y#{tournament.year}.eon.#{tournament.pga_id}.html"
+  end
+end

--- a/spec/services/url_builder_spec.rb
+++ b/spec/services/url_builder_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.describe UrlBuilder, type: :service do
+  describe 'when the data source is for results' do
+    it 'returns a url for the results page using the name of the most-recent tournament with the same pga_id' do
+      source = create(:data_source, stat: DataSource::RESULTS, pga_id: 'sourceId')
+      tournament1 = create(:tournament, year: 2015, pga_id: 'tourneyId', name: 'Wrong Name')
+      tournament2 = create(:tournament, year: 2016, pga_id: 'tourneyId', name: 'Also Wrong')
+      tournament3 = create(:tournament, year: 2017, pga_id: 'tourneyId', name: 'Correct Name')
+
+      expect(UrlBuilder.build(source, tournament1)).to eql("https://www.pgatour.com/tournaments/correct-name/past-results/jcr:content/mainParsys/pastresults.selectedYear.2015.html")
+      expect(UrlBuilder.build(source, tournament2)).to eql("https://www.pgatour.com/tournaments/correct-name/past-results/jcr:content/mainParsys/pastresults.selectedYear.2016.html")
+      expect(UrlBuilder.build(source, tournament3)).to eql("https://www.pgatour.com/tournaments/correct-name/past-results/jcr:content/mainParsys/pastresults.selectedYear.2017.html")
+
+    end
+  end
+
+  describe 'when the data source is for stats' do
+    it 'returns a url for the stats page' do
+      source = create(:data_source, stat: 'birdies', pga_id: 'sourceId')
+      tournament = create(:tournament, year: 2019, pga_id: 'tourneyId')
+
+      expect(UrlBuilder.build(source, tournament)).to eql("https://www.pgatour.com/stats/stat.sourceId.y2019.eon.tourneyId.html")
+    end
+  end
+end


### PR DESCRIPTION
The correct results page URL has the name of the most-recent tournament with the same `pga_id`, but we're currently just filling it in with the given tournament name. This PR fixes that, and moves the url-creation logic into a new service to encapsulate that logic and make it more easily-testable.