### PR TITLE
Update TournamentScraperWorker to be used for individual tournaments

### DIFF
--- a/app/workers/tournament_scraper_worker.rb
+++ b/app/workers/tournament_scraper_worker.rb
@@ -1,7 +1,7 @@
 class TournamentScraperWorker < ApplicationWorker
   sidekiq_options retry: false
 
-  def perform
-    Scraper.scrape_for_new_tournaments
+  def perform(pga_id)
+    Scraper.new.scrape_tournament_series(pga_id)
   end
 end

--- a/config/sidekiq_scheduler.yml
+++ b/config/sidekiq_scheduler.yml
@@ -1,5 +1,2 @@
-TournamentScraperWorker:
-  cron: "0 0 * * mon"
-
 DataScraperWorker:
   cron: "0 1 * * mon"

--- a/spec/workers/tournament_scraper_worker_spec.rb
+++ b/spec/workers/tournament_scraper_worker_spec.rb
@@ -2,15 +2,19 @@ require 'rails_helper'
 
 RSpec.describe TournamentScraperWorker, type: :worker do
   describe '#perform' do
+    let(:scraper) { instance_double(Scraper) }
+
+    before do
+      allow(scraper).to receive(:scrape_tournament_series)
+      allow(Scraper).to receive(:new).and_return(scraper)
+    end
 
     subject(:worker) { TournamentScraperWorker.new }
 
-    it 'calls #scrape_for_new_tournaments on TournamentScraper' do
-      allow(Scraper).to receive(:scrape_for_new_tournaments)
+    it 'calls #scrape_tournament_series on TournamentScraper with the correct args' do
+      worker.perform('t000')
 
-      worker.perform
-
-      expect(Scraper).to have_received(:scrape_for_new_tournaments)
+      expect(scraper).to have_received(:scrape_tournament_series).with('t000')
     end
   end
 end


### PR DESCRIPTION
Currently the `TournamentScraperWorker` is set up to scrape all tournaments, which we don't want (yet). This updates the worker to instead just fetch data for a single tournament, which we do want.