### PR TITLE
Remove ampersands before building URL

### DIFF
--- a/app/services/url_builder.rb
+++ b/app/services/url_builder.rb
@@ -21,7 +21,7 @@ class UrlBuilder
   attr_reader :source, :tournament
 
   def tournament_name
-    most_recent_matching_tournament.name.gsub(" ", "-").downcase
+    most_recent_matching_tournament.name.gsub('& ', '').gsub(" ", "-").downcase
   end
 
   def most_recent_matching_tournament

--- a/spec/services/url_builder_spec.rb
+++ b/spec/services/url_builder_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe UrlBuilder, type: :service do
       source = create(:data_source, stat: DataSource::RESULTS, pga_id: 'sourceId')
       tournament1 = create(:tournament, year: 2015, pga_id: 'tourneyId', name: 'Wrong Name')
       tournament2 = create(:tournament, year: 2016, pga_id: 'tourneyId', name: 'Also Wrong')
-      tournament3 = create(:tournament, year: 2017, pga_id: 'tourneyId', name: 'Correct Name')
+      tournament3 = create(:tournament, year: 2017, pga_id: 'tourneyId', name: 'Correct & Name')
 
       expect(UrlBuilder.build(source, tournament1)).to eql("https://www.pgatour.com/tournaments/correct-name/past-results/jcr:content/mainParsys/pastresults.selectedYear.2015.html")
       expect(UrlBuilder.build(source, tournament2)).to eql("https://www.pgatour.com/tournaments/correct-name/past-results/jcr:content/mainParsys/pastresults.selectedYear.2016.html")


### PR DESCRIPTION
If a tournament has an ampersand in the name, it gets built into the URL. This is wrong because the corresponding results pages for these tournaments do not have that ampersand in the URL.

Current example:
https://www.pgatour.com/tournaments/corales-puntacana-resort-&-club-championship/past-results/jcr:content/mainParsys/pastresults.selectedYear.2019.html

Correct example:
https://www.pgatour.com/tournaments/corales-puntacana-resort-club-championship/past-results/jcr:content/mainParsys/pastresults.selectedYear.2019.html